### PR TITLE
Mirror of awslabs aws-encryption-sdk-java#46

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -42,6 +42,7 @@ import com.amazonaws.encryptionsdk.exception.UnsupportedProviderException;
 import com.amazonaws.handlers.RequestHandler2;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClient;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
@@ -560,7 +561,7 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
     private static Region getStartingRegion(final String keyArn) {
         final String region = parseRegionfromKeyArn(keyArn);
         if (region != null) {
-            return Region.getRegion(Regions.fromName(region));
+            return RegionUtils.getRegion(region);
         }
         final Region currentRegion = Regions.getCurrentRegion();
         if (currentRegion != null) {


### PR DESCRIPTION
Mirror of awslabs aws-encryption-sdk-java#46
Move to using RegionUtils.getRegion instead of Region.getRegion(Regions.fromName()).

This is the recommended approach from the AWS SDK team.
