### PR TITLE
Mirror of awslabs aws-encryption-sdk-java#44

### DIFF
--- a/src/test/java/com/amazonaws/services/kms/LegacyKMSMasterKeyProviderTests.java
+++ b/src/test/java/com/amazonaws/services/kms/LegacyKMSMasterKeyProviderTests.java
@@ -56,10 +56,10 @@ public class LegacyKMSMasterKeyProviderTests {
             }
         };
 
-        MasterKeyProvider<KmsMasterKey> mkp = new KmsMasterKeyProvider(creds, "arn:aws:kms:us-east-1:012345678901);key/foo-bar");
+        MasterKeyProvider<KmsMasterKey> mkp = new KmsMasterKeyProvider(creds, "arn:aws:kms:us-east-1:012345678901:key/foo-bar");
         assertExplicitCredentialsUsed(mkp);
 
-        mkp = new KmsMasterKeyProvider(new AWSStaticCredentialsProvider(creds), "arn:aws:kms:us-east-1:012345678901);key/foo-bar");
+        mkp = new KmsMasterKeyProvider(new AWSStaticCredentialsProvider(creds), "arn:aws:kms:us-east-1:012345678901:key/foo-bar");
         assertExplicitCredentialsUsed(mkp);
     }
 


### PR DESCRIPTION
Mirror of awslabs aws-encryption-sdk-java#44
The logic to set the UA suffix to include the SDK version was dropped as part of the new builder refactoring. This change restores it.

Also included is a minor fix to a test (this didn't break anything but should be fixed out of general tidiness).
