### PR TITLE
Mirror of awslabs aws-encryption-sdk-java#22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.1
+
+### Minor changes
+
+* Frame sizes are once again required to be aligned to 16 bytes
+  This restriction was relaxed in 1.3.0, but due to compatibility concerns
+  we'll put this restriction back in for the time being.
+
 ## 1.3.0
 
 ### Major changes

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can get the latest release from Maven:
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.3.1-STAGING</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.1-STAGING</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>

--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -137,6 +137,11 @@ public class AwsCrypto {
         if (frameSize < 0) {
             throw new IllegalArgumentException("frameSize must be non-negative");
         }
+        if (frameSize % 16 != 0) {
+            // For compatibility reasons we'll still enforce this restriction for now.
+            // TODO: Investigate whether this can be removed.
+            throw new IllegalArgumentException("frameSize must be a multiple of 16");
+        }
         encryptionFrameSize_ = frameSize;
     }
 

--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
@@ -640,49 +640,10 @@ public class AwsCryptoTest {
         assertEquals(setFrameSize, getFrameSize);
     }
 
-    @Test
-    public void unalignedFrameSizesAreAccepted() throws IOException {
+    @Test(expected = IllegalArgumentException.class)
+    public void unalignedFrameSizesAreRejected() throws IOException {
         final int frameSize = AwsCrypto.getDefaultCryptoAlgorithm().getBlockSize() - 1;
         encryptionClient_.setEncryptionFrameSize(frameSize);
-
-        // Make sure we can encrypt with unaligned small frame sizes.
-        encryptionClient_.decryptData(masterKeyProvider,
-                                      encryptionClient_.encryptData(masterKeyProvider, new byte[1]).getResult());
-
-        encryptionClient_.setEncryptionFrameSize(frameSize + 2);
-        encryptionClient_.decryptData(masterKeyProvider,
-                                      encryptionClient_.encryptData(masterKeyProvider, new byte[1]).getResult());
-
-        // Make sure really large frame sizes work too.
-        // Note that going all the way up to Integer.MAX_VALUE hits JVM limits.
-        encryptionClient_.setEncryptionFrameSize(Integer.MAX_VALUE - 16);
-        OutputStream nullOutputStream = new OutputStream() {
-            @Override public void write(final int b) throws IOException {
-
-            }
-
-            @Override public void write(final byte[] b) throws IOException {
-
-            }
-
-            @Override public void write(final byte[] b, final int off, final int len) throws IOException {
-
-            }
-        };
-
-        OutputStream decrypter = encryptionClient_.createDecryptingStream(masterKeyProvider, nullOutputStream);
-        OutputStream encrypter = encryptionClient_.createEncryptingStream(masterKeyProvider, nullOutputStream);
-
-        byte[] buf = new byte[1024*1024];
-        long bytesRemaining = Integer.MAX_VALUE + 1;
-
-        while (bytesRemaining > 0) {
-            int toWrite = Math.toIntExact(Math.min(buf.length, bytesRemaining));
-
-            encrypter.write(buf, 0, toWrite);
-        }
-
-        encrypter.close();
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Mirror of awslabs aws-encryption-sdk-java#22
Restoring these for now due to concerns about compatibility with relaxing this
restriction.
