### PR TITLE
Mirror of awslabs aws-encryption-sdk-java#12

### DIFF
--- a/src/examples/java/com/amazonaws/crypto/examples/StringExample.java
+++ b/src/examples/java/com/amazonaws/crypto/examples/StringExample.java
@@ -68,8 +68,8 @@ public class StringExample {
 
         // The SDK may add information to the encryption context, so we check to ensure
         // that all of our values are present
-        for (final Map.Entry<String, String> e : context.entrySet()) {
-            if (!e.getValue().equals(decryptResult.getEncryptionContext().get(e.getKey()))) {
+        for (final Map.Entry<String, String> e : decryptResult.getEncryptionContext().entrySet()) {
+            if (!e.getValue().equals(context.get(e.getKey()))) {
                 throw new IllegalStateException("Wrong Encryption Context!");
             }
         }

--- a/src/examples/java/com/amazonaws/crypto/examples/StringExample.java
+++ b/src/examples/java/com/amazonaws/crypto/examples/StringExample.java
@@ -69,7 +69,7 @@ public class StringExample {
         // The SDK may add information to the encryption context, so we check to ensure
         // that all of our values are present
         for (final Map.Entry<String, String> e : decryptResult.getEncryptionContext().entrySet()) {
-            if (!e.getValue().equals(context.get(e.getKey()))) {
+            if (!e.getValue().equals(context.get(e.getKey())) && !e.getKey().equals(Constants.EC_PUBLIC_KEY_FIELD)) {
                 throw new IllegalStateException("Wrong Encryption Context!");
             }
         }


### PR DESCRIPTION
Mirror of awslabs aws-encryption-sdk-java#12
The check should be dictated by the encryptionContext, not the provided context, as in it's existing form, if an empty context is provided, the decrypt operation would still be successful. This would bypass the point of the encryptionContext entirely.
