### PR TITLE
Mirror of aws aws-encryption-sdk-java#51

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -450,6 +450,11 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
         }
 
         String regionName = parseRegionfromKeyArn(keyId);
+
+        if (regionName == null && defaultRegion_ != null) {
+            regionName = defaultRegion_;
+        }
+
         AWSKMS kms = regionalClientSupplier_.getClient(regionName);
         if (kms == null) {
             throw new AwsCryptoException("Can't use keys from region " + regionName);


### PR DESCRIPTION
Mirror of aws aws-encryption-sdk-java#51
The default region was not actually being consulted when presented with a
regionless key ID (such as a bare UUID or an "alias/foo" value). Fixes #50.
