### PR TITLE
Mirror of aws aws-encryption-sdk-java#45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.2
+
+### Minor Changes
+* Frame size restriction removed again
+* Support Builders for use with AWS KMS
+* Fix estimateCipherText when used with cached data keys
+* Do not automatically set a default region in KmsMasterKeyProvider
+
 ## 1.3.1
 
 ### Minor changes

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can get the latest release from Maven:
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.3.1-STAGING</version>
+    <version>1.3.2</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.2-STAGING</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>


### PR DESCRIPTION
Mirror of aws aws-encryption-sdk-java#45
Modify version numbers to version 1.3.2 for new release
