### PR TITLE
Mirror of aws aws-encryption-sdk-java#97

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ You can find more examples in the [examples directory][examples].
 
 ## Public API
 
-The public API that we will maintain within the constraints of our [versioning policy](./VERSIONING.rst)
-consists of all public classes in the `com.amazonaws.encryptionsdk` package unless otherwise and specifically documented.
+The public API that we maintain includes all public classes in the in the `com.amazonaws.encryptionsdk`
+package unless otherwise documented. Our [versioning policy](./VERSIONING.rst) applies to this public API.
 
 The `com.amazonaws.encryptionsdk.internal` package is not included in this public API.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ public class StringExample {
 
 You can find more examples in the [examples directory][examples].
 
+## Public API
+
+The public API that we will maintain within the constraints of our [versioning policy](./VERSIONING.rst)
+consists of all public classes in the `com.amazonaws.encryptionsdk` package unless otherwise and specifically documented.
+
+The `com.amazonaws.encryptionsdk.internal` package is not included in this public API.
+
 ## FAQ
 
 See the [Frequently Asked Questions](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/faq.html) page in the official documentation.


### PR DESCRIPTION
Mirror of aws aws-encryption-sdk-java#97
*Description of changes:*
Adding an explicit definition of our public API to avoid confusion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

