### PR TITLE
Mirror of aws aws-encryption-sdk-java#110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.6.0 -- 2019-05-31
+
+### Minor Changes
+* Remove dependency on Apache Commons Codec 1.12.
+* Use Base64 encoder from Bouncy Castle.
+* Introduce and use utility methods for Base64 encoding/decoding so that
+  switching the codec provider needs to be done only in one place next time.
+
 ## 1.5.0 -- 2019-05-30
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can get the latest release from Maven:
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>
@@ -91,12 +91,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.12</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -19,8 +19,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.commons.codec.binary.Base64;
-
 import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.exception.BadCiphertextException;
 import com.amazonaws.encryptionsdk.internal.DecryptionHandler;
@@ -308,7 +306,7 @@ public class AwsCrypto {
                 plaintext.getBytes(StandardCharsets.UTF_8),
                 encryptionContext
         );
-        return new CryptoResult<>(Base64.encodeBase64String(ctBytes.getResult()),
+        return new CryptoResult<>(Utils.encodeBase64String(ctBytes.getResult()),
                                   ctBytes.getMasterKeys(), ctBytes.getHeaders());
     }
 
@@ -424,7 +422,7 @@ public class AwsCrypto {
         Utils.assertNonNull(provider, "provider");
         final byte[] ciphertextBytes;
         try {
-            ciphertextBytes = Base64.decodeBase64(Utils.assertNonNull(ciphertext, "ciphertext"));
+            ciphertextBytes = Utils.decodeBase64String(Utils.assertNonNull(ciphertext, "ciphertext"));
         } catch (final IllegalArgumentException ex) {
             throw new BadCiphertextException("Invalid base 64", ex);
         }

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
@@ -14,8 +14,6 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.bouncycastle.math.ec.ECPoint;
 
-import org.apache.commons.codec.binary.Base64;
-
 import com.amazonaws.encryptionsdk.CryptoAlgorithm;
 
 import static com.amazonaws.encryptionsdk.internal.BouncyCastleConfiguration.INTERNAL_BOUNCY_CASTLE_PROVIDER;
@@ -70,7 +68,7 @@ public abstract class TrailingSignatureAlgorithm {
 
         @Override
         public PublicKey deserializePublicKey(String keyString) {
-            final ECPoint q = ecSpec.getCurve().decodePoint(Base64.decodeBase64(keyString));
+            final ECPoint q = ecSpec.getCurve().decodePoint(Utils.decodeBase64String(keyString));
 
             ECPublicKeyParameters keyParams = new ECPublicKeyParameters(
                     q,
@@ -82,7 +80,7 @@ public abstract class TrailingSignatureAlgorithm {
 
         @Override
         public String serializePublicKey(PublicKey key) {
-            return Base64.encodeBase64String(((ECPublicKey)key).getQ().getEncoded(true));
+            return Utils.encodeBase64String(((ECPublicKey)key).getQ().getEncoded(true));
         }
 
         @Override

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/Utils.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/Utils.java
@@ -23,6 +23,8 @@ import java.util.Comparator;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.bouncycastle.util.encoders.Base64;
+
 /**
  * Internal utility methods.
  */
@@ -256,5 +258,25 @@ public final class Utils {
     public static ByteBuffer limit(final ByteBuffer buff, final int newLimit) {
         ((Buffer) buff).limit(newLimit);
         return buff;
+    }
+
+    /**
+     * Takes a Base64-encoded String, decodes it, and returns contents as a byte array.
+     *
+     * @param encoded Base64 encoded String
+     * @return decoded data as a byte array
+     */
+    public static byte[] decodeBase64String(final String encoded) {
+        return Base64.decode(encoded);
+    }
+
+    /**
+     * Takes data in a byte array, encodes them in Base64, and returns the result as a String.
+     *
+     * @param data The data to encode.
+     * @return Base64 string that encodes the {@code data}.
+     */
+    public static String encodeBase64String(final byte[] data) {
+        return Base64.toBase64String(data);
     }
 }

--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
@@ -41,14 +41,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.commons.codec.binary.Base64;
-
 import com.amazonaws.encryptionsdk.caching.CachingCryptoMaterialsManager;
 import com.amazonaws.encryptionsdk.caching.LocalCryptoMaterialsCache;
 import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.exception.BadCiphertextException;
 import com.amazonaws.encryptionsdk.internal.StaticMasterKey;
 import com.amazonaws.encryptionsdk.internal.TestIOUtils;
+import com.amazonaws.encryptionsdk.internal.Utils;
 import com.amazonaws.encryptionsdk.model.CiphertextType;
 import com.amazonaws.encryptionsdk.model.DecryptionMaterials;
 import com.amazonaws.encryptionsdk.model.DecryptionMaterialsRequest;
@@ -450,7 +449,7 @@ public class AwsCryptoTest {
                 encryptionContext).getResult();
         final String decryptedText = encryptionClient_.decryptString(
                 masterKeyProvider,
-                Base64.encodeBase64String(cipherText)).getResult();
+                Utils.encodeBase64String(cipherText)).getResult();
 
         assertEquals(plaintext, decryptedText);
     }
@@ -470,7 +469,7 @@ public class AwsCryptoTest {
                 encryptionContext).getResult();
         final byte[] decryptedText = encryptionClient_.decryptData(
                 masterKeyProvider,
-                Base64.decodeBase64(ciphertext)).getResult();
+                Utils.decodeBase64String(ciphertext)).getResult();
 
         assertArrayEquals(plaintextString.getBytes(StandardCharsets.UTF_8), decryptedText);
     }

--- a/src/test/java/com/amazonaws/encryptionsdk/UtilsTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/UtilsTest.java
@@ -1,9 +1,11 @@
 package com.amazonaws.encryptionsdk;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -73,6 +75,26 @@ public class UtilsTest {
         assertEquals(Long.MAX_VALUE, Utils.saturatingAdd(Long.MAX_VALUE - 1, +2));
         assertEquals(Long.MAX_VALUE, Utils.saturatingAdd(Long.MAX_VALUE, Long.MAX_VALUE));
         assertEquals(Long.MIN_VALUE, Utils.saturatingAdd(Long.MIN_VALUE, Long.MIN_VALUE));
+    }
+
+    /**
+     * Basic sanity check for our Base64 helper methods.
+     */
+    @Test
+    public void base64empty() {
+        assertEquals("", Utils.encodeBase64String(new byte[]{}));
+        assertArrayEquals(new byte[]{}, Utils.decodeBase64String(""));
+    }
+
+    /**
+     * Basic sanity check for our Base64 helper methods.
+     */
+    @Test
+    public void base64something() {
+        byte[] data = "Lorem ipsum dolor sit amet".getBytes(StandardCharsets.UTF_8);
+        String encoded = "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ=";
+        assertEquals(encoded, Utils.encodeBase64String(data));
+        assertArrayEquals(data, Utils.decodeBase64String(encoded));
     }
 }
 

--- a/src/test/java/com/amazonaws/encryptionsdk/XCompatDecryptTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/XCompatDecryptTest.java
@@ -32,18 +32,17 @@ import java.util.Map;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.codec.binary.Base64;
 
 import org.bouncycastle.util.io.pem.PemReader;
 
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import com.amazonaws.encryptionsdk.internal.Utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 
@@ -120,7 +119,7 @@ public class XCompatDecryptTest {
                 byte[] keyBytes;
                 switch ((String)thisKey.get("encoding")) {
                     case "base64":
-                        keyBytes = Base64.decodeBase64(keyRaw);
+                        keyBytes = Utils.decodeBase64String(keyRaw);
                         break;
                     case "pem":
                         PemReader pemReader = new PemReader(new StringReader(keyRaw));

--- a/src/test/java/com/amazonaws/encryptionsdk/caching/CacheIdentifierTests.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/caching/CacheIdentifierTests.java
@@ -17,10 +17,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
-import org.apache.commons.codec.binary.Base64;
 
 import com.amazonaws.encryptionsdk.CryptoAlgorithm;
 import com.amazonaws.encryptionsdk.CryptoMaterialsManager;
+import com.amazonaws.encryptionsdk.internal.Utils;
 import com.amazonaws.encryptionsdk.model.DecryptionMaterialsRequest;
 import com.amazonaws.encryptionsdk.model.EncryptionMaterialsRequest;
 import com.amazonaws.encryptionsdk.model.KeyBlob;
@@ -84,7 +84,7 @@ public class CacheIdentifierTests {
 
         byte[] id = getCacheIdentifier(getCMM(partitionName), request);
 
-        assertEquals(expect, Base64.encodeBase64String(id));
+        assertEquals(expect, Utils.encodeBase64String(id));
     }
 
     void assertEncryptId(String partitionName, CryptoAlgorithm algo, Map<String, String> context, String expect) throws Exception {
@@ -95,7 +95,7 @@ public class CacheIdentifierTests {
 
         byte[] id = getCacheIdentifier(getCMM(partitionName), request);
 
-        assertEquals(expect, Base64.encodeBase64String(id));
+        assertEquals(expect, Utils.encodeBase64String(id));
     }
 
     @Test

--- a/src/test/java/com/amazonaws/encryptionsdk/internal/StaticMasterKey.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/internal/StaticMasterKey.java
@@ -20,8 +20,6 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.codec.binary.Base64;
-
 import com.amazonaws.encryptionsdk.CryptoAlgorithm;
 import com.amazonaws.encryptionsdk.DataKey;
 import com.amazonaws.encryptionsdk.EncryptedDataKey;
@@ -181,8 +179,8 @@ public class StaticMasterKey extends MasterKey<StaticMasterKey> {
     /**
      * Statically configured private key.
      */
-    private static final byte[] privateKey_v1 = Base64.decodeBase64(
-            ("MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAKLpwqjYtYExVilW/Hg0ogWv9xZ+"
+    private static final byte[] privateKey_v1 = Utils.decodeBase64String(
+            "MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAKLpwqjYtYExVilW/Hg0ogWv9xZ+"
     + "THj4IzvISLlPtK8W6KXMcqukfuxdYmndPv8UD1DbdHFYSSistdqoBN32vVQOQnJZyYm45i2TDOV0"
     + "M2DtHtR6aMMlBLGtdPeeaT88nQfI1ORjRDyR1byMwomvmKifZYga6FjLt/sgqfSE9BUnAgMBAAEC"
     + "gYAqnewGL2qLuVRIzDCPYXVg938zqyZmHsNYyDP+BhPGGcASX0FAFW/+dQ9hkjcAk0bOaBo17Fp3"
@@ -193,15 +191,14 @@ public class StaticMasterKey extends MasterKey<StaticMasterKey> {
     + "4mSYYs9UZ0S1DAMhl6amPpqIANYX98NJyZUsjtNV9MK2qoUSF/xXqDFvxG1lAkBhP5Ow2Zn3U1mT"
     + "Y/XQxSZjjjwr3vyt1neHjQsEMwa3iGPXJbLSmVBVZfUZoGOBDsvVQoCIiFOlGuKyBpA45MkZAkAH"
     + "ksUrS9xLrDIUOI2BzMNRsK0bH7KJ+PFxm2SBgJOF9+Uf2A9LIP4IvESZq+ufp6c8YaqgR6Id1vws"
-    + "7rUyGoa5").getBytes(StandardCharsets.UTF_8));
+    + "7rUyGoa5");
 
     /**
      * Statically configured public key.
      */
-     private static final byte[] publicKey_v1 = Base64.decodeBase64(
-            ("MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCi6cKo2LWBMVYpVvx4NKIFr/cWfkx4+CM7yEi5"
+     private static final byte[] publicKey_v1 = Utils.decodeBase64String(
+            "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCi6cKo2LWBMVYpVvx4NKIFr/cWfkx4+CM7yEi5"
     + "T7SvFuilzHKrpH7sXWJp3T7/FA9Q23RxWEkorLXaqATd9r1UDkJyWcmJuOYtkwzldDNg7R7UemjD"
-    + "JQSxrXT3nmk/PJ0HyNTkY0Q8kdW8jMKJr5ion2WIGuhYy7f7IKn0hPQVJwIDAQAB")
-             .getBytes(StandardCharsets.UTF_8));
+    + "JQSxrXT3nmk/PJ0HyNTkY0Q8kdW8jMKJr5ion2WIGuhYy7f7IKn0hPQVJwIDAQAB");
 
 }

--- a/src/test/java/com/amazonaws/encryptionsdk/model/ByteFormatCheckValues.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/ByteFormatCheckValues.java
@@ -13,7 +13,7 @@
 
 package com.amazonaws.encryptionsdk.model;
 
-import org.apache.commons.codec.binary.Base64;
+import com.amazonaws.encryptionsdk.internal.Utils;
 
 public class ByteFormatCheckValues {
     private static final String base64MessageId_ = "NQ/NXvg4mMN5zm5JFZHUWw==";
@@ -29,38 +29,38 @@ public class ByteFormatCheckValues {
     private static final String base64FinalFrameHeaderHash_ = "/b2fVFOxvnaM5vXDMGyyFPNTWMjuU/c/48qeH3uTHj0=";
 
     public static byte[] getMessageId() {
-        return Base64.decodeBase64(base64MessageId_);
+        return Utils.decodeBase64String(base64MessageId_);
     }
 
     public static byte[] getEncryptedKey() {
-        return Base64.decodeBase64(base64EncryptedKey_);
+        return Utils.decodeBase64String(base64EncryptedKey_);
     }
 
     public static byte[] getPlaintextKey() {
-        return Base64.decodeBase64(base64PlaintextKey_);
+        return Utils.decodeBase64String(base64PlaintextKey_);
     }
 
     public static byte[] getCiphertextHeaderHash() {
-        return Base64.decodeBase64(base64CiphertextHeaderHash_);
+        return Utils.decodeBase64String(base64CiphertextHeaderHash_);
     }
 
     public static byte[] getCipherBlockHeaderHash() {
-        return Base64.decodeBase64(base64BlockHeaderHash_);
+        return Utils.decodeBase64String(base64BlockHeaderHash_);
     }
 
     public static byte[] getCipherFrameHeaderHash() {
-        return Base64.decodeBase64(base64FrameHeaderHash_);
+        return Utils.decodeBase64String(base64FrameHeaderHash_);
     }
 
     public static byte[] getCipherFinalFrameHeaderHash() {
-        return Base64.decodeBase64(base64FinalFrameHeaderHash_);
+        return Utils.decodeBase64String(base64FinalFrameHeaderHash_);
     }
 
     public static byte[] getNonce() {
-        return Base64.decodeBase64(base64Nonce_);
+        return Utils.decodeBase64String(base64Nonce_);
     }
 
     public static byte[] getTag() {
-        return Base64.decodeBase64(base64Tag_);
+        return Utils.decodeBase64String(base64Tag_);
     }
 }


### PR DESCRIPTION
Mirror of aws aws-encryption-sdk-java#110
### Description of changes
Turns out adding a dependency on Apache Commons Codec is not a good idea so we'll use Base64 codec from BouncyCastle for now. I've added utility methods for Base64 encoding/decoding so the next time we change Base64 codec we can make the change in one place.

### Testing
* `mvn clean install` passes

### Licence
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

