### PR TITLE
Mirror of aws aws-encryption-sdk-java#109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.4.2 -- 2019-05-30
+## 1.5.0 -- 2019-05-30
 
 ### Minor Changes
 * Add dependency on Apache Commons Codec 1.12.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.4.2 -- 2019-05-30
+
+### Minor Changes
+* Add dependency on Apache Commons Codec 1.12.
+* Use org.apache.commons.codec.binary.Base64 instead of java.util.Base64 so
+  that the SDK can be used on systems that do not have java.util.Base64 but
+  support Java 8 language features.
+
+### Maintenance
+* Upgrade AWS Java SDK version from 1.11.169 to 1.11.561.
+* Upgrade Mockito from 2.23.4 to 2.28.1.
+* Upgrade Apache Commons Lang from 3.4 to 3.9.
+
 ## 1.4.1 -- 2019-05-10
 
 ### Patches

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can get the latest release from Maven:
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.4.1</version>
+  <version>1.4.2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can get the latest release from Maven:
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.4.2</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.4.2</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.169</version>
+            <version>1.11.561</version>
             <optional>true</optional>
         </dependency>
 
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
+            <version>2.28.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -90,7 +90,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.9</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.12</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -16,9 +16,10 @@ package com.amazonaws.encryptionsdk;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
+
+import org.apache.commons.codec.binary.Base64;
 
 import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.exception.BadCiphertextException;
@@ -307,7 +308,7 @@ public class AwsCrypto {
                 plaintext.getBytes(StandardCharsets.UTF_8),
                 encryptionContext
         );
-        return new CryptoResult<>(Base64.getEncoder().encodeToString(ctBytes.getResult()),
+        return new CryptoResult<>(Base64.encodeBase64String(ctBytes.getResult()),
                                   ctBytes.getMasterKeys(), ctBytes.getHeaders());
     }
 
@@ -423,7 +424,7 @@ public class AwsCrypto {
         Utils.assertNonNull(provider, "provider");
         final byte[] ciphertextBytes;
         try {
-            ciphertextBytes = Base64.getDecoder().decode(Utils.assertNonNull(ciphertext, "ciphertext"));
+            ciphertextBytes = Base64.decodeBase64(Utils.assertNonNull(ciphertext, "ciphertext"));
         } catch (final IllegalArgumentException ex) {
             throw new BadCiphertextException("Invalid base 64", ex);
         }

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
@@ -14,7 +14,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.bouncycastle.math.ec.ECPoint;
 
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 
 import com.amazonaws.encryptionsdk.CryptoAlgorithm;
 
@@ -70,7 +70,7 @@ public abstract class TrailingSignatureAlgorithm {
 
         @Override
         public PublicKey deserializePublicKey(String keyString) {
-            final ECPoint q = ecSpec.getCurve().decodePoint(Base64.getDecoder().decode(keyString));
+            final ECPoint q = ecSpec.getCurve().decodePoint(Base64.decodeBase64(keyString));
 
             ECPublicKeyParameters keyParams = new ECPublicKeyParameters(
                     q,
@@ -82,7 +82,7 @@ public abstract class TrailingSignatureAlgorithm {
 
         @Override
         public String serializePublicKey(PublicKey key) {
-            return Base64.getEncoder().encodeToString(((ECPublicKey)key).getQ().getEncoded(true));
+            return Base64.encodeBase64String(((ECPublicKey)key).getQ().getEncoded(true));
         }
 
         @Override

--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.apache.commons.codec.binary.Base64;
 
 import com.amazonaws.encryptionsdk.caching.CachingCryptoMaterialsManager;
 import com.amazonaws.encryptionsdk.caching.LocalCryptoMaterialsCache;
@@ -449,7 +450,7 @@ public class AwsCryptoTest {
                 encryptionContext).getResult();
         final String decryptedText = encryptionClient_.decryptString(
                 masterKeyProvider,
-                Base64.getEncoder().encodeToString(cipherText)).getResult();
+                Base64.encodeBase64String(cipherText)).getResult();
 
         assertEquals(plaintext, decryptedText);
     }
@@ -469,7 +470,7 @@ public class AwsCryptoTest {
                 encryptionContext).getResult();
         final byte[] decryptedText = encryptionClient_.decryptData(
                 masterKeyProvider,
-                Base64.getDecoder().decode(ciphertext)).getResult();
+                Base64.decodeBase64(ciphertext)).getResult();
 
         assertArrayEquals(plaintextString.getBytes(StandardCharsets.UTF_8), decryptedText);
     }

--- a/src/test/java/com/amazonaws/encryptionsdk/XCompatDecryptTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/XCompatDecryptTest.java
@@ -23,7 +23,6 @@ import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,6 +32,7 @@ import java.util.Map;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.codec.binary.Base64;
 
 import org.bouncycastle.util.io.pem.PemReader;
 
@@ -120,7 +120,7 @@ public class XCompatDecryptTest {
                 byte[] keyBytes;
                 switch ((String)thisKey.get("encoding")) {
                     case "base64":
-                        keyBytes = Base64.getDecoder().decode(keyRaw);
+                        keyBytes = Base64.decodeBase64(keyRaw);
                         break;
                     case "pem":
                         PemReader pemReader = new PemReader(new StringReader(keyRaw));

--- a/src/test/java/com/amazonaws/encryptionsdk/caching/CacheIdentifierTests.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/caching/CacheIdentifierTests.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.mock;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -18,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
+import org.apache.commons.codec.binary.Base64;
 
 import com.amazonaws.encryptionsdk.CryptoAlgorithm;
 import com.amazonaws.encryptionsdk.CryptoMaterialsManager;
@@ -84,7 +84,7 @@ public class CacheIdentifierTests {
 
         byte[] id = getCacheIdentifier(getCMM(partitionName), request);
 
-        assertEquals(expect, Base64.getEncoder().encodeToString(id));
+        assertEquals(expect, Base64.encodeBase64String(id));
     }
 
     void assertEncryptId(String partitionName, CryptoAlgorithm algo, Map<String, String> context, String expect) throws Exception {
@@ -95,7 +95,7 @@ public class CacheIdentifierTests {
 
         byte[] id = getCacheIdentifier(getCMM(partitionName), request);
 
-        assertEquals(expect, Base64.getEncoder().encodeToString(id));
+        assertEquals(expect, Base64.encodeBase64String(id));
     }
 
     @Test

--- a/src/test/java/com/amazonaws/encryptionsdk/internal/StaticMasterKey.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/internal/StaticMasterKey.java
@@ -9,7 +9,6 @@ import java.security.SecureRandom;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -20,6 +19,8 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Base64;
 
 import com.amazonaws.encryptionsdk.CryptoAlgorithm;
 import com.amazonaws.encryptionsdk.DataKey;
@@ -180,7 +181,7 @@ public class StaticMasterKey extends MasterKey<StaticMasterKey> {
     /**
      * Statically configured private key.
      */
-    private static final byte[] privateKey_v1 = Base64.getDecoder().decode(
+    private static final byte[] privateKey_v1 = Base64.decodeBase64(
             ("MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAKLpwqjYtYExVilW/Hg0ogWv9xZ+"
     + "THj4IzvISLlPtK8W6KXMcqukfuxdYmndPv8UD1DbdHFYSSistdqoBN32vVQOQnJZyYm45i2TDOV0"
     + "M2DtHtR6aMMlBLGtdPeeaT88nQfI1ORjRDyR1byMwomvmKifZYga6FjLt/sgqfSE9BUnAgMBAAEC"
@@ -197,7 +198,7 @@ public class StaticMasterKey extends MasterKey<StaticMasterKey> {
     /**
      * Statically configured public key.
      */
-     private static final byte[] publicKey_v1 = Base64.getDecoder().decode(
+     private static final byte[] publicKey_v1 = Base64.decodeBase64(
             ("MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCi6cKo2LWBMVYpVvx4NKIFr/cWfkx4+CM7yEi5"
     + "T7SvFuilzHKrpH7sXWJp3T7/FA9Q23RxWEkorLXaqATd9r1UDkJyWcmJuOYtkwzldDNg7R7UemjD"
     + "JQSxrXT3nmk/PJ0HyNTkY0Q8kdW8jMKJr5ion2WIGuhYy7f7IKn0hPQVJwIDAQAB")

--- a/src/test/java/com/amazonaws/encryptionsdk/model/ByteFormatCheckValues.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/ByteFormatCheckValues.java
@@ -13,7 +13,7 @@
 
 package com.amazonaws.encryptionsdk.model;
 
-import java.util.Base64;
+import org.apache.commons.codec.binary.Base64;
 
 public class ByteFormatCheckValues {
     private static final String base64MessageId_ = "NQ/NXvg4mMN5zm5JFZHUWw==";
@@ -29,38 +29,38 @@ public class ByteFormatCheckValues {
     private static final String base64FinalFrameHeaderHash_ = "/b2fVFOxvnaM5vXDMGyyFPNTWMjuU/c/48qeH3uTHj0=";
 
     public static byte[] getMessageId() {
-        return Base64.getDecoder().decode(base64MessageId_);
+        return Base64.decodeBase64(base64MessageId_);
     }
 
     public static byte[] getEncryptedKey() {
-        return Base64.getDecoder().decode(base64EncryptedKey_);
+        return Base64.decodeBase64(base64EncryptedKey_);
     }
 
     public static byte[] getPlaintextKey() {
-        return Base64.getDecoder().decode(base64PlaintextKey_);
+        return Base64.decodeBase64(base64PlaintextKey_);
     }
 
     public static byte[] getCiphertextHeaderHash() {
-        return Base64.getDecoder().decode(base64CiphertextHeaderHash_);
+        return Base64.decodeBase64(base64CiphertextHeaderHash_);
     }
 
     public static byte[] getCipherBlockHeaderHash() {
-        return Base64.getDecoder().decode(base64BlockHeaderHash_);
+        return Base64.decodeBase64(base64BlockHeaderHash_);
     }
 
     public static byte[] getCipherFrameHeaderHash() {
-        return Base64.getDecoder().decode(base64FrameHeaderHash_);
+        return Base64.decodeBase64(base64FrameHeaderHash_);
     }
 
     public static byte[] getCipherFinalFrameHeaderHash() {
-        return Base64.getDecoder().decode(base64FinalFrameHeaderHash_);
+        return Base64.decodeBase64(base64FinalFrameHeaderHash_);
     }
 
     public static byte[] getNonce() {
-        return Base64.getDecoder().decode(base64Nonce_);
+        return Base64.decodeBase64(base64Nonce_);
     }
 
     public static byte[] getTag() {
-        return Base64.getDecoder().decode(base64Tag_);
+        return Base64.decodeBase64(base64Tag_);
     }
 }


### PR DESCRIPTION
Mirror of aws aws-encryption-sdk-java#109
### Description of changes
* This change switches Base64 codec from java.util.Base64 to Base64 from Apache Commons Codec. This is to enable use of this library on systems that do not contain java.util.Base64 but do support other Java 8 features.
* Upgrade dependencies to their most recent versions.
* Bump version to 1.5.0

### Testing
* `mvn verify` passes on my laptop and runs AllTestsSuite with its 5726 tests.
* Travis CI tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

