### PR TITLE
Mirror of aws aws-encryption-sdk-java#119

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/ParsedCiphertext.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/ParsedCiphertext.java
@@ -15,7 +15,6 @@ package com.amazonaws.encryptionsdk;
 
 import com.amazonaws.encryptionsdk.internal.Utils;
 import com.amazonaws.encryptionsdk.model.CiphertextHeaders;
-import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.exception.BadCiphertextException;
 import com.amazonaws.encryptionsdk.exception.ParseException;
 
@@ -38,9 +37,8 @@ public class ParsedCiphertext extends CiphertextHeaders {
      */
     public ParsedCiphertext(final byte[] ciphertext) throws ParseException {
         ciphertext_ = Utils.assertNonNull(ciphertext, "ciphertext");
-        if (isComplete()) {
-          offset_ = deserialize(ciphertext_, 0);
-        } else {
+        offset_ = deserialize(ciphertext_, 0);
+        if (!this.isComplete()) {
           throw new BadCiphertextException("Incomplete ciphertext.");
         }
     }

--- a/src/main/java/com/amazonaws/encryptionsdk/ParsedCiphertext.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/ParsedCiphertext.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except
  * in compliance with the License. A copy of the License is located at
- * 
+ *
  * http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -15,6 +15,9 @@ package com.amazonaws.encryptionsdk;
 
 import com.amazonaws.encryptionsdk.internal.Utils;
 import com.amazonaws.encryptionsdk.model.CiphertextHeaders;
+import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
+import com.amazonaws.encryptionsdk.exception.BadCiphertextException;
+import com.amazonaws.encryptionsdk.exception.ParseException;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -33,9 +36,13 @@ public class ParsedCiphertext extends CiphertextHeaders {
      * {@code ciphertext} and that any changes made to the backing array will be reflected here as
      * well.
      */
-    public ParsedCiphertext(final byte[] ciphertext) {
+    public ParsedCiphertext(final byte[] ciphertext) throws ParseException {
         ciphertext_ = Utils.assertNonNull(ciphertext, "ciphertext");
-        offset_ = deserialize(ciphertext_, 0);
+        if (ciphertext.isComplete()) {
+          offset_ = deserialize(ciphertext_, 0);
+        } else {
+          throw new BadCiphertextException("Incomplete ciphertext.");
+        }
     }
 
     /**

--- a/src/main/java/com/amazonaws/encryptionsdk/ParsedCiphertext.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/ParsedCiphertext.java
@@ -38,7 +38,7 @@ public class ParsedCiphertext extends CiphertextHeaders {
      */
     public ParsedCiphertext(final byte[] ciphertext) throws ParseException {
         ciphertext_ = Utils.assertNonNull(ciphertext, "ciphertext");
-        if (ciphertext.isComplete()) {
+        if (isComplete()) {
           offset_ = deserialize(ciphertext_, 0);
         } else {
           throw new BadCiphertextException("Incomplete ciphertext.");

--- a/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except
  * in compliance with the License. A copy of the License is located at
- * 
+ *
  * http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -161,10 +161,10 @@ public class CiphertextHeadersTest {
      * dataKey_ = new AWSKMSDataKey(testKey_, encryptedKey_);
      * headerNonce_ = ByteFormatCheckValues.getNonce();
      * headerTag_ = ByteFormatCheckValues.getTag();
-     * 
+     *
      * Map<String, String> encryptionContext = new HashMap<String, String>(1);
      * encryptionContext.put("ENC", "CiphertextHeader format check test");
-     * 
+     *
      * final CiphertextHeaders ciphertextHeaders =
      * createCiphertextHeaders(encryptionContext);
      * //NOTE: this test will fail because of the line below.
@@ -173,7 +173,7 @@ public class CiphertextHeadersTest {
      * messageId_ = ciphertextHeaders.getMessageId();
      * final byte[] ciphertextHeaderHash =
      * TestIOUtils.getSha256Hash(ciphertextHeaders.toByteArray());
-     * 
+     *
      * assertArrayEquals(ByteFormatCheckValues.getCiphertextHeaderHash(),
      * ciphertextHeaderHash);
      * }
@@ -312,6 +312,24 @@ public class CiphertextHeadersTest {
     private void readUptoNonceLen(final ByteBuffer headerBuff) {
         readUptoReservedField(headerBuff);
         headerBuff.get();
+    }
+
+    @Test(expected = BadCiphertextException.class)
+    public void incompleteCiphertext() {
+        final Map<String, String> encryptionContext = new HashMap<String, String>(1);
+        encryptionContext.put("ENC", "CiphertextHeader Streaming Test");
+
+        final CiphertextHeaders ciphertextHeaders = createCiphertextHeaders(encryptionContext);
+        final byte[] headerBytes = ciphertextHeaders.toByteArray();
+        final ByteBuffer headerBuff = ByteBuffer.wrap(headerBytes);
+
+        readUptoVersion(headerBuff);
+
+        // set ciphertext to incomplete.
+        headerBuff.put((byte) 0);
+
+        final CiphertextHeaders reconstructedHeaders = new CiphertextHeaders();
+        reconstructedHeaders.deserialize(headerBuff.array(), 0);
     }
 
     @Test(expected = BadCiphertextException.class)


### PR DESCRIPTION
Mirror of aws aws-encryption-sdk-java#119
#114 

Added a check as well as a test to make sure `isComplete_` is true before returning from the `ParsedCiphertext` constructor.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.


